### PR TITLE
Wrong line on cssLoaders when using ExtractTextPlugin

### DIFF
--- a/generators/app/conf.js
+++ b/generators/app/conf.js
@@ -123,7 +123,7 @@ module.exports = function webpackConf(options) {
       if (options.css === 'styl') {
         test = lit`/\\.(css|styl|stylus)$/`;
       }
-      cssLoaders = lit`ExtractTextPlugin.extract('style', 'css?minimize!${mapToLoaders[options.css]}', 'postcss')`;
+      cssLoaders = lit`ExtractTextPlugin.extract('style', 'css?minimize!${mapToLoaders[options.css]}!postcss')`;
     } else {
       cssLoaders = ['style', 'css'];
       if (options.css === 'scss') {

--- a/test/app/conf.js
+++ b/test/app/conf.js
@@ -217,7 +217,7 @@ test('conf with angular1/scss/js', t => {
       loaders: [
         {
           test: lit`/\\.(css|scss)$/`,
-          loaders: lit`ExtractTextPlugin.extract('style', 'css?minimize!sass', 'postcss')`
+          loaders: lit`ExtractTextPlugin.extract('style', 'css?minimize!sass!postcss')`
         },
         {
           test: lit`/\\.js$/`,
@@ -272,7 +272,7 @@ test('conf with angular1/scss/js', t => {
       loaders: [
         {
           test: lit`/\\.(css|scss)$/`,
-          loaders: lit`ExtractTextPlugin.extract('style', 'css?minimize!sass', 'postcss')`
+          loaders: lit`ExtractTextPlugin.extract('style', 'css?minimize!sass!postcss')`
         },
         {
           test: lit`/\\.js$/`,
@@ -327,7 +327,7 @@ test('conf with angular1/styl/typescript', t => {
       loaders: [
         {
           test: lit`/\\.(css|styl|stylus)$/`,
-          loaders: lit`ExtractTextPlugin.extract('style', 'css?minimize!stylus', 'postcss')`
+          loaders: lit`ExtractTextPlugin.extract('style', 'css?minimize!stylus!postcss')`
         },
         {
           test: lit`/\\.ts$/`,
@@ -391,7 +391,7 @@ test('conf with angular2/less/typescript', t => {
       loaders: [
         {
           test: lit`/\\.(css|less)$/`,
-          loaders: lit`ExtractTextPlugin.extract('style', 'css?minimize!less', 'postcss')`
+          loaders: lit`ExtractTextPlugin.extract('style', 'css?minimize!less!postcss')`
         },
         {
           test: lit`/\\.ts$/`,
@@ -528,7 +528,7 @@ test('conf with angular2/css/js', t => {
       loaders: [
         {
           test: lit`/\\.css$/`,
-          loaders: lit`ExtractTextPlugin.extract('style', 'css?minimize!', 'postcss')`
+          loaders: lit`ExtractTextPlugin.extract('style', 'css?minimize!!postcss')`
         },
         {
           test: lit`/\.html$/`,


### PR DESCRIPTION
There is a [wrong usage of `ExtractTextPlugin`](https://github.com/FountainJS/generator-fountain-webpack/blob/master/generators/app/conf.js#L126) when configuring the css loader that is not loading the `postcss-loader` well.
