### PR TITLE
Upgrade ts-loader to v0.8.2

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -40,7 +40,7 @@ module.exports = fountain.Base.extend({
 
       if (this.options.js === 'typescript') {
         Object.assign(pkg.devDependencies, {
-          'ts-loader': '^0.7.2'
+          'ts-loader': '^0.8.2'
         });
       }
 

--- a/test/app/index.js
+++ b/test/app/index.js
@@ -59,7 +59,7 @@ test('Configuring package.json with angular1/babel/css', t => {
 test('Configuring package.json with angular2/typescript/css', t => {
   const expected = _.merge({}, pkg, {
     devDependencies: {
-      'ts-loader': '^0.7.2',
+      'ts-loader': '^0.8.2',
       'html-loader': '^0.4.3'
     }
   });


### PR DESCRIPTION
Fix : on files changes, the webpack watcher serve the version n-1.
Now : when we change a file, webpack outputs the current version of the code
