### PR TITLE
Fix errorHandler to come from gulp.conf

### DIFF
--- a/generators/app/templates/gulp_tasks/webpack.js
+++ b/generators/app/templates/gulp_tasks/webpack.js
@@ -4,6 +4,7 @@ const gutil = require('gulp-util');
 const webpack = require('webpack');
 const webpackConf = require('../conf/webpack.conf');
 const webpackDistConf = require('../conf/webpack-dist.conf');
+const gulpConf = require('../conf/gulp.conf');
 <% if (framework !== 'react') { -%>
 const browsersync = require('browser-sync');
 <% } -%>
@@ -25,7 +26,7 @@ function webpackWrapper(watch, conf, done) {
 
   const webpackChangeHandler = (err, stats) => {
     if (err) {
-      conf.errorHandler('Webpack')(err);
+      gulpConf.errorHandler('Webpack')(err);
     }
     gutil.log(stats.toString({
       colors: true,


### PR DESCRIPTION
Fixes https://github.com/FountainJS/generator-fountain-webpack/issues/46
