### PR TITLE
Set devtool conf with 'source-map'

### DIFF
--- a/generators/app/conf.js
+++ b/generators/app/conf.js
@@ -27,7 +27,7 @@ module.exports = function webpackConf(options) {
 
   if (options.dist === false) {
     conf.debug = true;
-    conf.devtool = 'cheap-module-eval-source-map';
+    conf.devtool = 'source-map';
     if (options.test === false) {
       conf.output = {
         path: lit`path.join(process.cwd(), conf.paths.tmp)`,

--- a/test/app/conf.js
+++ b/test/app/conf.js
@@ -53,7 +53,7 @@ test('conf dev with react/css/babel', t => {
     ],
     postcss: lit`() => [autoprefixer]`,
     debug: true,
-    devtool: 'cheap-module-eval-source-map',
+    devtool: 'source-map',
     output: {
       path: lit`path.join(process.cwd(), conf.paths.tmp)`,
       filename: 'index.js'
@@ -100,7 +100,7 @@ test('conf dev with react/scss/babel', t => {
     ],
     postcss: lit`() => [autoprefixer]`,
     debug: true,
-    devtool: 'cheap-module-eval-source-map',
+    devtool: 'source-map',
     output: {
       path: lit`path.join(process.cwd(), conf.paths.tmp)`,
       filename: 'index.js'
@@ -147,7 +147,7 @@ test('conf dev with react/less/babel', t => {
     ],
     postcss: lit`() => [autoprefixer]`,
     debug: true,
-    devtool: 'cheap-module-eval-source-map',
+    devtool: 'source-map',
     output: {
       path: lit`path.join(process.cwd(), conf.paths.tmp)`,
       filename: 'index.js'
@@ -182,7 +182,7 @@ test('conf test with react/css/typescript', t => {
       ]
     },
     debug: true,
-    devtool: 'cheap-module-eval-source-map',
+    devtool: 'source-map',
     resolve: {
       extensions: ['', '.webpack.js', '.web.js', '.js', '.ts', '.tsx']
     },
@@ -543,7 +543,7 @@ test('conf with react/css/babel', t => {
       ]
     },
     debug: true,
-    devtool: 'cheap-module-eval-source-map',
+    devtool: 'source-map',
     externals: {
       'react/lib/ExecutionEnvironment': true,
       'react/lib/ReactContext': true
@@ -564,7 +564,7 @@ test('conf with angular2/css/babel', t => {
   const expected = merge([{}, conf, {
     plugins: [],
     debug: true,
-    devtool: 'cheap-module-eval-source-map',
+    devtool: 'source-map',
     module: {
       loaders: [
         {
@@ -675,7 +675,7 @@ test('conf with react/css/typescript', t => {
     ],
     postcss: lit`() => [autoprefixer]`,
     debug: true,
-    devtool: 'cheap-module-eval-source-map',
+    devtool: 'source-map',
     output: {
       path: lit`path.join(process.cwd(), conf.paths.tmp)`,
       filename: 'index.js'
@@ -710,7 +710,7 @@ test('conf with vue/css/babel', t => {
   const expected = merge([{}, conf, {
     plugins: [],
     debug: true,
-    devtool: 'cheap-module-eval-source-map',
+    devtool: 'source-map',
     module: {
       loaders: [
         {


### PR DESCRIPTION
Here's a proposal to change devtool conf from `cheap-eval-source-map` with `source-map`:

Source file doesn't seem to be found with `cheap-eval-source-map` as shown on the screenshot:

![cheap-eval-source-map](https://cloud.githubusercontent.com/assets/463319/18555174/2ac7ca00-7b67-11e6-8d77-be46d627bad5.png)

whereas it's correctly working with `source-map`:

![source-map](https://cloud.githubusercontent.com/assets/463319/18555177/2f908b80-7b67-11e6-8225-9a78974cbf40.png)
