### PR TITLE
Add Webpack fail plugin

### DIFF
--- a/generators/app/conf.js
+++ b/generators/app/conf.js
@@ -26,6 +26,7 @@ module.exports = function webpackConf(options) {
     conf.plugins = [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoErrorsPlugin()`,
+      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -13,7 +13,8 @@ module.exports = fountain.Base.extend({
           'postcss-loader': '^0.8.0',
           'autoprefixer': '^6.2.2',
           'json-loader': '^0.5.4',
-          'extract-text-webpack-plugin': '^2.0.0-beta.3'
+          'extract-text-webpack-plugin': '^2.0.0-beta.3',
+          'webpack-fail-plugin': '^1.0.5'
         }
       };
 

--- a/generators/app/templates/conf/webpack.conf.js
+++ b/generators/app/templates/conf/webpack.conf.js
@@ -7,6 +7,7 @@ const path = require('path');
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 <%   if (dist === true) { -%>
+const FailPlugin = require('webpack-fail-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 <%     if (framework !== 'angular2') { -%>
 const pkg = require('../package.json');

--- a/test/app/conf.js
+++ b/test/app/conf.js
@@ -51,6 +51,7 @@ test('conf dev with react/css/babel', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoErrorsPlugin()`,
+      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -107,6 +108,7 @@ test('conf dev with react/scss/babel', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoErrorsPlugin()`,
+      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -163,6 +165,7 @@ test('conf dev with react/less/babel', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoErrorsPlugin()`,
+      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -281,6 +284,7 @@ test('conf with angular1/scss/js', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoErrorsPlugin()`,
+      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -346,6 +350,7 @@ test('conf with angular1/scss/js', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoErrorsPlugin()`,
+      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -411,6 +416,7 @@ test('conf with angular1/styl/typescript', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoErrorsPlugin()`,
+      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -489,6 +495,7 @@ test('conf with angular2/less/typescript', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoErrorsPlugin()`,
+      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -573,6 +580,7 @@ test('conf with angular2/less/typescript/todoMVC', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoErrorsPlugin()`,
+      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -732,6 +740,7 @@ test('conf with angular2/css/js', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoErrorsPlugin()`,
+      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -798,6 +807,7 @@ test('conf with react/css/typescript', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoErrorsPlugin()`,
+      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,

--- a/test/app/conf.js
+++ b/test/app/conf.js
@@ -922,6 +922,7 @@ test('conf with react/css/typescript/todoMVC', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoErrorsPlugin()`,
+      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,

--- a/test/app/index.js
+++ b/test/app/index.js
@@ -28,7 +28,8 @@ const pkg = {
     'postcss-loader': '^0.8.0',
     'autoprefixer': '^6.2.2',
     'json-loader': '^0.5.4',
-    'extract-text-webpack-plugin': '^2.0.0-beta.3'
+    'extract-text-webpack-plugin': '^2.0.0-beta.3',
+    'webpack-fail-plugin': '^1.0.5'
   }
 };
 


### PR DESCRIPTION
It will return a correct status code when build failed

It must fixe issue #90

**Build will fail until release of fountain-generator**