### PR TITLE
Removes FailPlugin

### DIFF
--- a/generators/app/conf.js
+++ b/generators/app/conf.js
@@ -26,7 +26,6 @@ module.exports = function webpackConf(options) {
     conf.plugins = [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoEmitOnErrorsPlugin()`,
-      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -13,8 +13,7 @@ module.exports = fountain.Base.extend({
           'postcss-loader': '^1.3.1',
           'autoprefixer': '^6.7.3',
           'json-loader': '^0.5.4',
-          'extract-text-webpack-plugin': '^2.0.0-rc.3',
-          'webpack-fail-plugin': '^1.0.5'
+          'extract-text-webpack-plugin': '^2.0.0-rc.3'
         }
       };
 

--- a/generators/app/templates/conf/webpack.conf.js
+++ b/generators/app/templates/conf/webpack.conf.js
@@ -6,7 +6,6 @@ const conf = require('./gulp.conf');
 const path = require('path');
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const FailPlugin = require('webpack-fail-plugin');
 <%   if (dist === true) { -%>
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 <%     if (framework !== 'angular2') { -%>

--- a/test/app/conf.js
+++ b/test/app/conf.js
@@ -51,7 +51,6 @@ test('conf dev with react/css/babel', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoEmitOnErrorsPlugin()`,
-      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -108,7 +107,6 @@ test('conf dev with react/scss/babel', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoEmitOnErrorsPlugin()`,
-      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -165,7 +163,6 @@ test('conf dev with react/less/babel', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoEmitOnErrorsPlugin()`,
-      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -284,7 +281,6 @@ test('conf with angular1/scss/js', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoEmitOnErrorsPlugin()`,
-      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -351,7 +347,6 @@ test('conf with angular1/scss/js', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoEmitOnErrorsPlugin()`,
-      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -418,7 +413,6 @@ test('conf with angular1/styl/typescript', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoEmitOnErrorsPlugin()`,
-      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -498,7 +492,6 @@ test('conf with angular2/less/typescript', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoEmitOnErrorsPlugin()`,
-      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -584,7 +577,6 @@ test('conf with angular2/less/typescript/todoMVC', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoEmitOnErrorsPlugin()`,
-      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -745,7 +737,6 @@ test('conf with angular2/css/js', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoEmitOnErrorsPlugin()`,
-      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -813,7 +804,6 @@ test('conf with react/css/typescript', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoEmitOnErrorsPlugin()`,
-      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,
@@ -928,7 +918,6 @@ test('conf with react/css/typescript/todoMVC', t => {
     plugins: [
       lit`new webpack.optimize.OccurrenceOrderPlugin()`,
       lit`new webpack.NoEmitOnErrorsPlugin()`,
-      lit`FailPlugin`,
       lit`new HtmlWebpackPlugin({
       template: conf.path.src('index.html')
     })`,

--- a/test/app/index.js
+++ b/test/app/index.js
@@ -29,8 +29,7 @@ const pkg = {
     'postcss-loader': '^1.3.1',
     'autoprefixer': '^6.7.3',
     'json-loader': '^0.5.4',
-    'extract-text-webpack-plugin': '^2.0.0-rc.3',
-    'webpack-fail-plugin': '^1.0.5'
+    'extract-text-webpack-plugin': '^2.0.0-rc.3'
   }
 };
 


### PR DESCRIPTION
The plugin was [deprecated]( https://www.npmjs.com/package/webpack-fail-plugin), because webpack 2 replicates its behavior.